### PR TITLE
fix: update incorrect registry environment variable name

### DIFF
--- a/.github/workflows/push_images.yml
+++ b/.github/workflows/push_images.yml
@@ -105,6 +105,6 @@ jobs:
         with:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
-          registry: ${{ env.image_registry }}
+          registry: ${{ env.IMAGE_REGISTRY }}
           extra-args: |
             --disable-content-trust


### PR DESCRIPTION
The environment variables are case-sensitive.  We defined IMAGE_REGISTRY in the workflow but are trying to access it using image_registry