### PR TITLE
fix: update broken cosign steps and correct README rebase command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Sign container image
         if: github.event_name != 'pull_request'
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_EXPERIMENTAL: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,14 @@ jobs:
             SOURCE_IMAGE=${{ matrix.flavor }}
           oci: false
 
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -107,7 +115,7 @@ jobs:
         if: github.event_name != 'pull_request'
         id: push
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ steps.registry_case.outputs.lowercase }}
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
 
@@ -118,7 +126,7 @@ jobs:
       - name: Sign container image
         if: github.event_name != 'pull_request'
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}@${TAGS}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_EXPERIMENTAL: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,3 +131,17 @@ jobs:
           TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+
+  check:
+    name: Check all builds successful
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Exit on failure
+        if: ${{ needs.build.result == 'failure' }}
+        shell: bash
+        run: exit 1
+      - name: Exit
+        shell: bash
+        run: exit 0

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Disable SELinux (edit `/etc/selinux/config`, set from `enforcing` to `permissive
 Run this command:
 
 ```
-$ sudo rpm-ostree rebase ostree-image-signed:docker://:ghcr.io/ublue-os/cosmic-base:40-amd64
+$ sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/cosmic-base:40-amd64
 ```
 
 Or this command if you're running an arm device:
 
 ```
-$ sudo rpm-ostree rebase ostree-image-signed:docker://:ghcr.io/ublue-os/cosmic-base:40-arm64
+$ sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/cosmic-base:40-arm64
 ```
 
 Reboot


### PR DESCRIPTION
The cosign step will fail because we do not have the lowercase registry step.  
I think we could probably leave this step out, but since we use it everywhere else, I've kept it for now to match the other repos.