### PR TITLE
fix: use digest as tag when signing image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         id: push
         with:
           registry: ${{ steps.registry_case.outputs.lowercase }}
@@ -121,14 +121,14 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.4.0
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
 
       - name: Sign container image
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:
-          TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+          TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         id: push
         with:
           registry: ${{ steps.registry_case.outputs.lowercase }}
@@ -121,10 +121,10 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.4.0
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
 
       - name: Sign container image
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:


### PR DESCRIPTION
Looks like we are doing some funky stuff in main due to the retry actions.
We are not using the retry actions here, so I'll restore it to what we were using before retries.