### PR TITLE
feat: build ISO files

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
       id-token: write
     container:
-      image: fedora:latest
+      image: fedora:40
       options: "--privileged"
       volumes:
         - "/:/host"

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -1,0 +1,62 @@
+name: Build Cosmic ISOs
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build_iso.yml'
+
+env:
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-iso:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    container:
+      image: fedora:${{ matrix.major_version }}
+      options: "--privileged"
+      volumes:
+        - "/:/host"
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name: [cosmic-silverblue, cosmic-base]
+        image_tag: [40-amd64, rawhide-amd64]
+        include:
+          - image_tag: 40-amd64
+            major_version: 40
+          - image_tag: rawhide-amd64
+            major_version: 41 # We use F41 for rawhide
+            
+    steps:
+      - name: Build ISOs
+        uses: ublue-os/isogenerator@1.0.9
+        id: build
+        with:
+          ARCH: ${{ contains(matrix.image_tag, 'amd64') && 'x86_64' || 'arm64' }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          IMAGE_REPO: ghcr.io/ublue-os
+          VARIANT: 'Silverblue'
+          VERSION: ${{ matrix.major_version }}
+          IMAGE_TAG: ${{ matrix.image_tag }}
+          SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
+          ENROLLMENT_PASSWORD: 'ublue-os'
+
+      - name: Upload ISOs and Checksum to Job Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image_name }}-${{ matrix.image_tag }}-${{ matrix.major_version}}
+          path: ${{ steps.build.outputs.output-directory }}
+          if-no-files-found: error
+          retention-days: 0
+          compression-level: 0
+          overwrite: true

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -41,7 +41,7 @@ jobs:
           ARCH: ${{ contains(matrix.image_tag, 'amd64') && 'x86_64' || 'arm64' }}
           IMAGE_NAME: ${{ matrix.image_name }}
           IMAGE_REPO: ghcr.io/ublue-os
-          # Cannot use Silverblue variant since we need the user creation options in anaconda
+          # We cannot use Silverblue variant since we need the user creation options in anaconda
           VARIANT: 'Kinoite'
           VERSION: ${{ env.INSTALLER_VERSION }}
           IMAGE_TAG: ${{ matrix.image_tag }}
@@ -51,7 +51,7 @@ jobs:
       - name: Upload ISOs and Checksum to Job Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image_name }}-${{ matrix.image_tag }}-${{ matrix.major_version}}
+          name: ${{ matrix.image_name }}-${{ matrix.image_tag }}
           path: ${{ steps.build.outputs.output-directory }}
           if-no-files-found: error
           retention-days: 0

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
       id-token: write
     container:
-      image: fedora:${{ matrix.major_version }}
+      image: fedora:${{ env.INSTALLER_VERSION }}
       options: "--privileged"
       volumes:
         - "/:/host"

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  INSTALLER_VERSION: 40
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -31,11 +32,6 @@ jobs:
       matrix:
         image_name: [cosmic-silverblue, cosmic-base]
         image_tag: [40-amd64, rawhide-amd64]
-        include:
-          - image_tag: 40-amd64
-            major_version: 40
-          - image_tag: rawhide-amd64
-            major_version: rawhide
             
     steps:
       - name: Build ISOs
@@ -46,7 +42,7 @@ jobs:
           IMAGE_NAME: ${{ matrix.image_name }}
           IMAGE_REPO: ghcr.io/ublue-os
           VARIANT: 'Silverblue'
-          VERSION: ${{ matrix.major_version }}
+          VERSION: ${{ env.INSTALLER_VERSION }}
           IMAGE_TAG: ${{ matrix.image_tag }}
           SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
           ENROLLMENT_PASSWORD: 'ublue-os'

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  INSTALLER_VERSION: 39
+  INSTALLER_VERSION: 40
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -41,6 +41,7 @@ jobs:
           ARCH: ${{ contains(matrix.image_tag, 'amd64') && 'x86_64' || 'arm64' }}
           IMAGE_NAME: ${{ matrix.image_name }}
           IMAGE_REPO: ghcr.io/ublue-os
+          # Cannot use Silverblue variant since we need the user creation options in anaconda
           VARIANT: 'Kinoite'
           VERSION: ${{ env.INSTALLER_VERSION }}
           IMAGE_TAG: ${{ matrix.image_tag }}

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  INSTALLER_VERSION: 40
+  INSTALLER_VERSION: 39
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -41,7 +41,7 @@ jobs:
           ARCH: ${{ contains(matrix.image_tag, 'amd64') && 'x86_64' || 'arm64' }}
           IMAGE_NAME: ${{ matrix.image_name }}
           IMAGE_REPO: ghcr.io/ublue-os
-          VARIANT: 'Silverblue'
+          VARIANT: 'Kinoite'
           VERSION: ${{ env.INSTALLER_VERSION }}
           IMAGE_TAG: ${{ matrix.image_tag }}
           SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
       id-token: write
     container:
-      image: fedora:${{ env.INSTALLER_VERSION }}
+      image: fedora:latest
       options: "--privileged"
       volumes:
         - "/:/host"

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -35,7 +35,7 @@ jobs:
           - image_tag: 40-amd64
             major_version: 40
           - image_tag: rawhide-amd64
-            major_version: 41 # We use F41 for rawhide
+            major_version: rawhide
             
     steps:
       - name: Build ISOs


### PR DESCRIPTION
Builds ISO files and uploads them to GitHub Actions job artifacts.
These are not intended to be used in a production environment, and will likely have many bugs since Cosmic is not stable yet.
