### PR TITLE
feat: add fedora 39 to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        version: [40, rawhide]
+        version: [39, 40, rawhide]
         flavor: [base, silverblue]
     steps:
       # Checkout push-to-registry action GitHub repository


### PR DESCRIPTION
Due to popular request, I'm now building fedora 39 COSMIC packages on my COPR. This means that we can now support Fedora 39 COSMIC images.