### PR TITLE
fix: use cosmic-desktop instead of cosmic-epoch

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 RUN wget https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-40/ryanabx-cosmic-epoch-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ryanabx-cosmic.repo
 
 # Install cosmic desktop environment
-RUN rpm-ostree install cosmic-epoch
+RUN rpm-ostree install cosmic-desktop
 
 # Install extras (currently just a power manager and a libsecret manager)
 RUN rpm-ostree install \


### PR DESCRIPTION
I've changed the name of the cosmic-epoch package to cosmic-desktop and modified it a bit in the process of working on upstreaming the packages.

I will also make a PR to update the containerfile for rawhide once we get all the packages approved for fedora.