### PR TITLE
feat: add tuned-ppd, use systemctl enable --force

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,19 +9,24 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
 COPY greetd-workaround.service /usr/lib/systemd/system/greetd-workaround.service
 
 # Build in one step
-RUN bash -c "if [[ ${FEDORA_MAJOR_VERSION} == "rawhide" ]]; then \
+# Install tuned/tuned-ppd if the image is a base one
+RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
         curl -Lo /etc/yum.repos.d/_copr_ryanabx-cosmic.repo \
             https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-rawhide/ryanabx-cosmic-epoch-fedora-rawhide.repo \
-        ;else curl -Lo /etc/yum.repos.d/_copr_ryanabx-cosmic.repo \
-                https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-$(rpm -E %fedora)/ryanabx-cosmic-epoch-fedora-$(rpm -E %fedora).repo \
-        ; fi" && \
+    ; else curl -Lo /etc/yum.repos.d/_copr_ryanabx-cosmic.repo \
+            https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-$(rpm -E %fedora)/ryanabx-cosmic-epoch-fedora-$(rpm -E %fedora).repo \
+    ; fi && \
     rpm-ostree install \
         cosmic-desktop && \
+    rpm-ostree override remove \
+        power-profiles-daemon || true && \
+    rpm-ostree install tuned tuned-ppd && \
     rpm-ostree install \
-        tuned \
         gnome-keyring && \
-    rm -f /etc/systemd/system/display-manager.service && \
-    ln -s /usr/lib/systemd/system/cosmic-greeter.service /etc/systemd/system/display-manager.service && \
-    ln -s /usr/lib/systemd/system/greetd-workaround.service /etc/systemd/system/multi-user.target.wants/greetd-workaround.service && \
+    systemctl enable tuned-ppd && \
+    systemctl disable gdm || true && \
+    systemctl disable sddm || true && \
+    systemctl enable cosmic-greeter && \
+    systemctl enable greetd-workaround && \
     ostree container commit && \
     mkdir -p /var/tmp && chmod -R 1777 /var/tmp


### PR DESCRIPTION
This may need some regression testing, specifically on the `systemctl enable --force` stuff. I think this is a cleaner way of enabling the services, rather than just symlinking them manually.

We also should add tuned-ppd, which is a new compatibility layer between the power-profiles-daemon D-Bus API and tuned.

Edit:
power-profiles-daemon is still installed on silverblue and kinoite images, so we only need to find a power management solution for the base images.