### PR TITLE
chore: cleanup ISO builds

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  INSTALLER_VERSION: 40
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -26,21 +25,21 @@ jobs:
       fail-fast: false
       matrix:
         image_name: [cosmic-silverblue, cosmic-base]
-        image_tag: [40-amd64, rawhide-amd64]
-            
+        fedora_version: [40]
+
     steps:
       - name: Build ISOs
-        uses: jasonn3/build-container-installer@v1.2.1
+        uses: jasonn3/build-container-installer@v1.2.2
         id: build
         with:
-          arch: ${{ contains(matrix.image_tag, 'amd64') && 'x86_64' || 'arm64' }}
+          arch: x86_64
           image_name: ${{ matrix.image_name }}
           image_repo: ghcr.io/ublue-os
           enable_flatpak_dependencies: false
           # We cannot use Silverblue variant since we need the user creation options in anaconda
           variant: 'Kinoite'
-          version: ${{ env.INSTALLER_VERSION }}
-          image_tag: ${{ matrix.image_tag }}
+          version: ${{ matrix.fedora_version }}
+          image_tag: ${{ matrix.fedora_version }}-amd64
           secure_boot_key_url: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
           enrollment_password: 'ublue-os'
           iso_name: ${{ matrix.image_name }}-${{ steps.generate-tag.outputs.tag }}
@@ -48,7 +47,7 @@ jobs:
       - name: Upload ISOs and Checksum to Job Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image_name }}-${{ matrix.image_tag }}
+          name: ${{ matrix.image_name }}-${{ matrix.fedora_version }}-amd64
           path: |
             ${{ steps.build.outputs.iso_path }}
             ${{ steps.build.outputs.iso_path }}-CHECKSUM


### PR DESCRIPTION
Disables rawhide builds since nobody should use those... 
Refactors the workflow slightly to make variables more sensible.
Bumps the ISO builder action.

Does not host ISOs anywhere new.  Only available in GHA jobs.