### PR TITLE
feat: include sensible default flatpaks in ISO

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get Flatpak dependencies
         id: flatpak-dependencies
         env:
-          IMAGE_FULL: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
+          IMAGE_FULL: ${{ env.IMAGE_REGISTRY }}/${{ matrix.image_name }}:${{ env.IMAGE_TAG }}
         shell: bash
         run: |
           set -euox pipefail
@@ -57,6 +57,8 @@ jobs:
           while IFS= read -r line; do
             FLATPAK_REFS+=("$line")
           done < "${FLATPAK_REFS_DIR}/flatpaks.txt"
+
+          echo "Flatpak refs: ${FLATPAK_REFS[@]}"
 
           # Generate installation script
           cat <<EOF > "${TEMP_FLATPAK_INSTALL_DIR}/install-flatpaks.sh"

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/build_iso.yml'
+      - ".github/workflows/build_iso.yml"
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -24,30 +24,84 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_name: [cosmic, cosmic-nvidia, cosmic-silverblue,cosmic-silverblue-nvidia]
+        image_name:
+          [cosmic, cosmic-nvidia, cosmic-silverblue, cosmic-silverblue-nvidia]
         fedora_version: [40]
+    env:
+      IMAGE_TAG: ${{ matrix.fedora_version }}-amd64
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Flatpak dependencies
+        id: flatpak-dependencies
+        env:
+          IMAGE_FULL: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
+        shell: bash
+        run: |
+          set -euox pipefail
+
+          IMAGE="${IMAGE_FULL}"
+
+          # Create temporary directory
+          TEMP_FLATPAK_INSTALL_DIR=$(mktemp -d -p /tmp flatpak-XXXXXX)
+          FLATPAK_REFS_DIR=./flatpak-refs
+          FLATPAK_REFS_DIR_ABS=$(realpath "${FLATPAK_REFS_DIR}")
+          mkdir -p "${FLATPAK_REFS_DIR}"
+          mv flatpaks.txt "${FLATPAK_REFS_DIR_ABS}/flatpaks.txt"
+
+          # Read the list of Flatpak packages from the manifest
+          FLATPAK_REFS=()
+          while IFS= read -r line; do
+            FLATPAK_REFS+=("$line")
+          done < "${FLATPAK_REFS_DIR}/flatpaks.txt"
+
+          # Generate installation script
+          cat <<EOF > "${TEMP_FLATPAK_INSTALL_DIR}/install-flatpaks.sh"
+          mkdir -p /flatpak/flatpak /flatpak/triggers
+          mkdir /var/tmp
+          chmod -R 1777 /var/tmp
+          flatpak config --system --set languages "*"
+          flatpak remote-add --system flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --system -y flathub ${FLATPAK_REFS[@]}
+          ostree refs --repo=\${FLATPAK_SYSTEM_DIR}/repo | grep '^deploy/' | grep -v 'org\.freedesktop\.Platform\.openh264' | sed 's/^deploy\///g' > /output/flatpaks-with-deps
+          EOF
+          docker run --rm --privileged \
+            --entrypoint /bin/bash \
+            -e FLATPAK_SYSTEM_DIR=/flatpak/flatpak \
+            -e FLATPAK_TRIGGERS_DIR=/flatpak/triggers \
+            -v ${FLATPAK_REFS_DIR_ABS}:/output \
+            -v ${TEMP_FLATPAK_INSTALL_DIR}:/temp_flatpak_install_dir \
+            ${IMAGE} /temp_flatpak_install_dir/install-flatpaks.sh
+          docker rmi ${IMAGE}
+          cat ${FLATPAK_REFS_DIR}/flatpaks-with-deps
+
+          echo "FLATPAK_REFS_DIR=${FLATPAK_REFS_DIR}" >> $GITHUB_OUTPUT
+
       - name: Build ISOs
         uses: jasonn3/build-container-installer@v1.2.2
         id: build
         with:
+          iso_name: ${{ matrix.image_name }}-${{ matrix.fedora_version }}.iso
           arch: x86_64
           image_name: ${{ matrix.image_name }}
-          image_repo: ghcr.io/ublue-os
+          image_repo: ${{ env.IMAGE_REGISTRY }}
           enable_flatpak_dependencies: false
           # We cannot use Silverblue variant since we need the user creation options in anaconda
-          variant: 'Kinoite'
+          variant: "Kinoite"
           version: ${{ matrix.fedora_version }}
-          image_tag: ${{ matrix.fedora_version }}-amd64
-          secure_boot_key_url: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
-          enrollment_password: 'universalblue'
-          iso_name: ${{ matrix.image_name }}-${{ matrix.fedora_version }}.iso
+          image_tag: ${{ env.IMAGE_TAG }}
+          secure_boot_key_url: "https://github.com/ublue-os/akmods/raw/main/certs/public_key.der"
+          enrollment_password: "universalblue"
+          flatpak_remote_refs_dir: ${{ steps.flatpak-dependencies.outputs.FLATPAK_REFS_DIR }}
+          enable_flatpak_dependencies: false
 
       - name: Upload ISOs and Checksum to Job Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image_name }}-${{ matrix.fedora_version }}-amd64
+          name: ${{ matrix.image_name }}-${{ env.IMAGE_TAG }}
           path: |
             ${{ steps.build.outputs.iso_path }}
             ${{ steps.build.outputs.iso_path }}-CHECKSUM

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -88,7 +88,6 @@ jobs:
           arch: x86_64
           image_name: ${{ matrix.image_name }}
           image_repo: ${{ env.IMAGE_REGISTRY }}
-          enable_flatpak_dependencies: false
           # We cannot use Silverblue variant since we need the user creation options in anaconda
           variant: "Kinoite"
           version: ${{ matrix.fedora_version }}

--- a/flatpaks.txt
+++ b/flatpaks.txt
@@ -1,0 +1,17 @@
+app/com.github.tchx84.Flatseal/x86_64/stable
+app/io.missioncenter.MissionCenter/x86_64/stable
+app/org.mozilla.firefox/x86_64/stable
+app/org.mozilla.Thunderbird/x86_64/stable
+app/org.gnome.baobab/x86_64/stable
+app/org.gnome.Calculator/x86_64/stable
+app/org.gnome.Calendar/x86_64/stable
+app/org.gnome.Characters/x86_64/stable
+app/org.gnome.clocks/x86_64/stable
+app/org.gnome.Connections/x86_64/stable
+app/org.gnome.Contacts/x86_64/stable
+app/org.gnome.Papers/x86_64/stable
+app/org.gnome.font-viewer/x86_64/stable
+app/org.gnome.Logs/x86_64/stable
+app/org.gnome.Loupe/x86_64/stable
+app/org.gnome.Maps/x86_64/stable
+app/org.gnome.Weather/x86_64/stable


### PR DESCRIPTION
Users are not expected to extend the ISO we provide, and we are only providing the ISO as a sort of "tech demo".  This brings the ISO almost inline with the PopOS ISO.

I don't believe including these Flatpak packages is going to cause too many issues or confusion, especially after the recent README clarifications.  

I plan to add a simple oneshot service in the future to add the user Flathub Flatpak repo, since I consider the app store working to be basic functionality, and therefore fit the scope of the image.

Outside the changes in this PR and the proposed Flathub repo, I cannot think of any other basic functionality that's missing and should be fixed here.