### PR TITLE
fix: add power-profiles-daemon for power management

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,11 +14,13 @@ RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
             https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-$(rpm -E %fedora)/ryanabx-cosmic-epoch-fedora-$(rpm -E %fedora).repo \
     ; fi && \
     rpm-ostree install \
-        cosmic-desktop && \
+        cosmic-desktop \
+        power-profiles-daemon && \
     rpm-ostree install \
         gnome-keyring NetworkManager-tui && \
     systemctl disable gdm || true && \
     systemctl disable sddm || true && \
     systemctl enable cosmic-greeter && \
+    systemctl enable power-profiles-daemon && \
     ostree container commit && \
     mkdir -p /var/tmp && chmod -R 1777 /var/tmp


### PR DESCRIPTION
This would be included by upstream Fedora when adopted by them.  
Silverblue & Kinoite have their own power management services preinstalled.

The Cosmic settings page has a section that requires this service to be installed.

Previously PR'd in [here](https://github.com/ublue-os/cosmic/pull/44), but this was closed for an undisclosed reason.