### PR TITLE
feat: install NetworkManager-openvpn

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,8 @@ RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
         cosmic-desktop \
         power-profiles-daemon && \
     rpm-ostree install \
-        gnome-keyring NetworkManager-tui && \
+        gnome-keyring NetworkManager-tui \
+        NetworkManager-openvpn && \
     systemctl disable gdm || true && \
     systemctl disable sddm || true && \
     systemctl enable cosmic-greeter && \


### PR DESCRIPTION
Closes #78 

This package is required for using a VPN from within Cosmic settings.