### PR TITLE
chore: bump to F41

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         arch:
           - amd64
         version:
-          - 40
+          - 41
         flavor:
           - base
           - base-nvidia

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         image_name:
           [cosmic, cosmic-nvidia, cosmic-silverblue, cosmic-silverblue-nvidia]
-        fedora_version: [40]
+        fedora_version: [41]
     env:
       IMAGE_TAG: ${{ matrix.fedora_version }}-amd64
       IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,10 @@
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base-main}"
 ARG SOURCE_ORG="${SOURCE_ORG:-ghcr.io/ublue-os}"
 ARG BASE_IMAGE="${SOURCE_ORG}/${SOURCE_IMAGE}"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-41}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-41}"
 
 # Build in one step
 RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
@@ -14,14 +14,12 @@ RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
             https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-$(rpm -E %fedora)/ryanabx-cosmic-epoch-fedora-$(rpm -E %fedora).repo \
     ; fi && \
     rpm-ostree install \
-        cosmic-desktop \
-        power-profiles-daemon && \
+        cosmic-desktop && \
     rpm-ostree install \
         gnome-keyring NetworkManager-tui \
         NetworkManager-openvpn && \
     systemctl disable gdm || true && \
     systemctl disable sddm || true && \
     systemctl enable cosmic-greeter && \
-    systemctl enable power-profiles-daemon && \
     ostree container commit && \
     mkdir -p /var/tmp && chmod -R 1777 /var/tmp


### PR DESCRIPTION
Should fix the Build Problems with  #83 in that tuned and ppd conflict.
Removed ppd to fix it as tuned is the new standard for f41.
tuned and tuned-ppd seem to be included in the used images.

Build of images and isos worked for me https://github.com/herobrauni/ublue-cosmic/actions/runs/12031995039
