### PR TITLE
fix: Unlock gnome-keyring on login

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
     rpm-ostree install \
         cosmic-desktop && \
     rpm-ostree install \
-        gnome-keyring NetworkManager-tui \
+        gnome-keyring-pam NetworkManager-tui \
         NetworkManager-openvpn && \
     systemctl disable gdm || true && \
     systemctl disable sddm || true && \


### PR DESCRIPTION
The issue here was that gnome-keyring doesn't install the PAM modules for itself by default.

Note: gnome-keyring-pam will install gnome-keyring as well