### PR TITLE
fix: add xdg-user-dirs package to build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ RUN if [[ "${FEDORA_MAJOR_VERSION}" == "rawhide" ]]; then \
         cosmic-desktop && \
     rpm-ostree install \
         gnome-keyring-pam NetworkManager-tui \
-        NetworkManager-openvpn && \
+        NetworkManager-openvpn xdg-user-dirs && \
     systemctl disable gdm || true && \
     systemctl disable sddm || true && \
     systemctl enable cosmic-greeter && \


### PR DESCRIPTION
Added the package xdg-user-dirs to the initial build to ensure all home directories are properly created in fresh installs. This resolves this described issue with Firefox downloads: https://github.com/ublue-os/cosmic/issues/71